### PR TITLE
Erased big title below logo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 
 # Only for pushes
 before_deploy:
-  - date=`date +%Y-%m-d-%H-%M-%S`
+  - date=`date +%Y-%m-%d-%H-%M-%S`
 deploy:
   provider: s3
   access_key_id: AKIAJBDJHEBXXBRA6PKA

--- a/index.html
+++ b/index.html
@@ -73,7 +73,6 @@
                 <div class="col-lg-12">
                     <img class="img-responsive" src="img/logo.png" alt="Gedder Alarm Logo" width="300px" height="300px">
                     <div class="intro-text">
-                        <span class="name">Gedder Alarm</span>
                         <hr class="star-light">
                         <span class="skills">A smart, self-adjusting alarm clock to make sure you don't get late!</span>
                     </div>


### PR DESCRIPTION
Let me know if you guys think the site looks better with or without the big text "Gedder Alarm" below the logo.

Proposal: https://s3.amazonaws.com/gedderalarm.github.io/staging/2017-02-17-01-01-51/index.html
Current: https://gedderalarm.github.io/

Ignore the travis.yml change: had the date format wrong.